### PR TITLE
[bisos.iteration] Add step-table to info struct.

### DIFF
--- a/+bisos/+iteration/+step/biconv.m
+++ b/+bisos/+iteration/+step/biconv.m
@@ -24,7 +24,7 @@ methods
         
         if all(cellfun(@(v) ~isempty(sol.(v)), step.lvar))
             % perform convex subproblem
-            [sol,info,stop] = run(step.conv,prob,info,sol,symbols,assigns,options);
+            [sol,cinfo,stop] = run(step.conv,prob,info,sol,symbols,assigns,options);
             
             if stop, return; end
             
@@ -36,7 +36,7 @@ methods
             tub = obj0:+tol:tub;
         
             % information about convex subproblem
-            convsubprob = info.subprob;
+            convsubprob = getinfo(step.conv,cinfo);
         else
             convsubprob = [];
         end
@@ -49,9 +49,10 @@ methods
         [sol,info,stop] = run@bisos.iteration.step.bisect(step,prob,info,sol,symbols,assigns,options);
         
         % information about subproblems
-        info.subprob = [convsubprob info.subprob];
-    end
-            
+        subprob = getinfo(step,info);
+        subprob.convex = convsubprob;
+        info = setinfo(step,info,subprob);
+    end  
 end
     
 end 

--- a/+bisos/+iteration/+step/bisect.m
+++ b/+bisos/+iteration/+step/bisect.m
@@ -31,7 +31,7 @@ methods
         
         stepsol = goptimize(sosc,objective,sosoptions);
         
-        info.subprob.iter = stepsol.subiter;
+        info.bisections = stepsol.subiter;
     end
     
     function [sol,info,stop] = run(step,prob,info,sol,symbols,assigns,options)

--- a/+bisos/+iteration/@OptStep/run.m
+++ b/+bisos/+iteration/@OptStep/run.m
@@ -3,7 +3,7 @@ function [sol,info,stop] = run(step,prob,info,sol,symbols,assigns,options)
 
 sosc = newconstraints(prob.sosf,prob.x);
 
-info.subprob = [];
+subprob = [];
             
 for var=step.lvar
     [sosc,assigns.(var{:})] = instantiate(prob,sosc,var);
@@ -24,10 +24,12 @@ objective = bisos.subs(step.objective,symbols,assigns,step.variables);
 sosc = constraint(prob,sosc,step.cidx,symbols,assigns,step.variables);
 
 % solve optimization
-[stepsol,info] = solve(step,sosc,objective,info,options.sosoptions);
+[stepsol,subprob] = solve(step,sosc,objective,subprob,options.sosoptions);
 
 % information about subproblem
-info.subprob.size = stepsol.sizeLMI;
+subprob.LMIsize = stepsol.sizeLMI;
+
+info = setinfo(step,info,subprob);
 
 if ~stepsol.feas
     printf(options,'warning','Step %s infeasible at iteration %d.\n', tostr(step), info.iter);

--- a/+bisos/+iteration/Step.m
+++ b/+bisos/+iteration/Step.m
@@ -34,6 +34,19 @@ methods
 end
 
 methods (Access=protected)
+    function sub = getinfo(obj,info)
+        % Get step-specific information from info struct.
+        str = tostr(obj);
+        sub = info.steps.(str);
+    end
+    
+    function info = setinfo(obj,info,sub)
+        % Set step-specific information in info struct.
+        str = tostr(obj);
+        sub.stepname = str;
+        info.steps.(str) = sub;
+    end
+    
     function str = varin2str(obj)
         % String representation input variables.
         c = @(s) s(1:end-1);

--- a/+bisos/@Iteration/run.m
+++ b/+bisos/@Iteration/run.m
@@ -53,7 +53,8 @@ end
 sol.obj = Inf;
 % prepare array of solutions
 solution(options.Niter) = sol;
-stepinfo(numnodes(G),options.Niter) = struct('step',[],'sol',[],'info',[]);
+stepinfo(options.Niter) = cell(1);
+info.steps = table;
 
 while info.iter <= options.Niter
     % current step
@@ -61,11 +62,6 @@ while info.iter <= options.Niter
     
     % state-machine
     [sol,info,stop] = run(step,obj.prob,info,sol,symbols,struct,options);
-    
-    % save step solution and info for debug
-    stepinfo(sidx,info.iter).sol  = sol;
-    stepinfo(sidx,info.iter).info = info;
-    stepinfo(sidx,info.iter).step = tostr(step);
     
     if stop
         % Abort iteration
@@ -75,6 +71,7 @@ while info.iter <= options.Niter
     if strcmp(step.type, 'obj')
         %TODO: save solution to file
         solution(info.iter) = sol;
+        stepinfo(info.iter) = {info.steps};
     end
     
     %% compute next step
@@ -113,7 +110,7 @@ if stop >= 2
     sol = [];
 end
 
-info.steps = stepinfo(1:(info.iter*numnodes(G)+sidx));
+info.steps = vertcat(stepinfo{1:info.iter});
 
 finishlog(options,stop);
 


### PR DESCRIPTION
In response to Issue #12, this pull request adds a single-row table to the info struct that allows separate steps of [`bisos.iteration`] to log and store specific information. The table data can be accessed using the step signature (as returned by [`bisos.iteration.Step#tostr`](https://github.com/tcunis/bisosprob/blob/0d33fad4edfebc77d2bea0e97caa1d460d6b6c96/%2Bbisos/%2Biteration/Step.m#L23)).

For easy use, this pull requests also adds getter and setter as protected methods to `bisos.prob.Step`, namely [`getinfo`](https://github.com/tcunis/bisosprob/blob/0d33fad4edfebc77d2bea0e97caa1d460d6b6c96/%2Bbisos/%2Biteration/Step.m#L37) and [`setinfo`](https://github.com/tcunis/bisosprob/blob/0d33fad4edfebc77d2bea0e97caa1d460d6b6c96/%2Bbisos/%2Biteration/Step.m#L43), respectively.

After `bisos.iteration` is finished, the step-specific information of each iteration are returned in a table of which the number of rows corresponds to the number of iterations executed.