### PR TITLE
[bisos.iteration] Set info for initialization and objective

### DIFF
--- a/+bisos/+iteration/+step/init.m
+++ b/+bisos/+iteration/+step/init.m
@@ -16,16 +16,23 @@ methods
         % Run initialisation step.
         info.iter = info.iter + 1;
                 
-        stop = isfield(info,'converged') && info.converged;
-
-        if info.iter > 1
-            return;
+        if info.iter == 1
+            % initialize solution variables
+            for var=step.varout
+                [~,sol.(var{:})] = hasinitial(prob,var{:});
+            end
         end
         
-        % initialize solution variables
-        for var=step.varout
-            [~,sol.(var{:})] = hasinitial(prob,var{:});
-        end
+        stepinfo.sol = sol;
+        
+        info = setinfo(step,info,stepinfo);
+        
+        stop = isfield(info,'converged') && info.converged;
+    end
+    
+    function str = name(step)
+        % Overriding Step.name
+        str = sprintf('%s', step.type);
     end
 end
 

--- a/+bisos/+iteration/+step/objective.m
+++ b/+bisos/+iteration/+step/objective.m
@@ -21,9 +21,14 @@ methods
         % set objective
         sol.obj = evalobj(prob,symbols,assigns,step.variables);
         
+        stepinfo.sol   = sol;
+        stepinfo.value = sol.obj;
+        
         printf(options,'step','Objective = %g at iteration %d.\n', sol.obj, info.iter);
         
         writetofile(options,'step',sol,'iter%d',info.iter);
+        
+        info = setinfo(step,info,stepinfo);
         
         stop = false;
     end
@@ -36,6 +41,11 @@ methods
         writetofile(options,'result',sol,'result');
         
         stop = false;
+    end
+    
+    function str = name(step)
+        % Overriding Step.name
+        str = sprintf('%s', step.type);
     end
 end
 

--- a/+bisos/+iteration/Step.m
+++ b/+bisos/+iteration/Step.m
@@ -20,6 +20,11 @@ methods
         vars = union(obj.varin, obj.varout);
     end
     
+    function str = name(obj)
+        % Return step name.
+        str = tostr(obj);
+    end
+    
     function str = tostr(obj)
         % Return string representation for step.
         
@@ -36,13 +41,13 @@ end
 methods (Access=protected)
     function sub = getinfo(obj,info)
         % Get step-specific information from info struct.
-        str = tostr(obj);
+        str = obj.name;
         sub = info.steps.(str);
     end
     
     function info = setinfo(obj,info,sub)
         % Set step-specific information in info struct.
-        str = tostr(obj);
+        str = obj.name;
         sub.stepname = str;
         info.steps.(str) = sub;
     end

--- a/+bisos/@Iteration/run.m
+++ b/+bisos/@Iteration/run.m
@@ -51,8 +51,7 @@ for var=varnames
 end
 
 sol.obj = Inf;
-% prepare array of solutions
-solution(options.Niter) = sol;
+% prepare array of step information
 stepinfo(options.Niter) = cell(1);
 info.steps = table;
 
@@ -68,11 +67,7 @@ while info.iter <= options.Niter
         break;
     end
 
-    if strcmp(step.type, 'obj')
-        %TODO: save solution to file
-        solution(info.iter) = sol;
-        stepinfo(info.iter) = {info.steps};
-    end
+    stepinfo(info.iter) = {info.steps};
     
     %% compute next step
     % mark current node as visited
@@ -91,15 +86,16 @@ while info.iter <= options.Niter
     sidx = nidx;
 end
             
-% find iteration with minimal objective
-[~,imin] = min([solution.obj]);
-
 if info.iter > 1
     info.iter = info.iter - 1;
 end
+stepinfo = vertcat(stepinfo{1:info.iter});
+
+% find iteration with minimal objective
+[~,imin] = min([stepinfo.obj.value]);
 
 % set output
-sol = solution(imin);
+sol = stepinfo.obj(imin).sol;
 
 % evaluate final steps
 fstop = cellfun(@(step) run_final(step,obj.prob,info,sol,options), obj.steps);
@@ -110,7 +106,7 @@ if stop >= 2
     sol = [];
 end
 
-info.steps = vertcat(stepinfo{1:info.iter});
+info.steps = stepinfo;
 
 finishlog(options,stop);
 


### PR DESCRIPTION
This pull request makes use of the step-specific info structure (#14) to log solutions through the iteration. In particular, the necessity to check for the objective step in the [outer `run` method](https://github.com/tcunis/bisosprob/blob/master/%2Bbisos/%40Iteration/run.m#L71-L75) is removed.

